### PR TITLE
Support filtering backup by address

### DIFF
--- a/cli/bin/main.cpp
+++ b/cli/bin/main.cpp
@@ -519,6 +519,11 @@ int performBackup(etcpp::Session& session, cxxopts::ParseResult const& argParseR
         return EXIT_FAILURE;
     }
 
+    std::string addressFilter;
+    if (argParseResult.count("address")) {
+        addressFilter = argParseResult["address"].as<std::string>();
+    }
+
     // Telemetry - we'd like to know whether the user overwrote the default export path
     session.setUsingDefaultExportPath(!pathCameFromArgs && usingDefaultBackupPath);
 
@@ -533,7 +538,7 @@ int performBackup(etcpp::Session& session, cxxopts::ParseResult const& argParseR
 
     std::unique_ptr<BackupTask> backupTask;
     try {
-        backupTask = std::make_unique<BackupTask>(session, backupPath);
+        backupTask = std::make_unique<BackupTask>(session, backupPath, addressFilter);
     } catch (const etcpp::SessionException& e) {
         etLogError("Failed to create export task: {}", e.what());
         std::cerr << "Failed to create export task: " << e.what() << std::endl;
@@ -662,6 +667,7 @@ int main(int argc, const char** argv) {
             cxxopts::value<std::string>())("t,totp", "User's TOTP 2FA code (can also be set with env var ET_TOTP_CODE)",
                                            cxxopts::value<std::string>())(
             "u,user", "User's account/email (can also be set with env var ET_USER_EMAIL", cxxopts::value<std::string>())(
+            "a,address", "Email address to backup (defaults to all addresses)", cxxopts::value<std::string>())(
             "k, telemetry", "Disable anonymous telemetry statistics (can also be set with env var ET_TELEMETRY_OFF)", cxxopts::value<bool>())(
             "h,help", "Show help");
 

--- a/cli/bin/tasks/backup_task.cpp
+++ b/cli/bin/tasks/backup_task.cpp
@@ -19,8 +19,9 @@
 #include <etsession.hpp>
 #include <iostream>
 
-BackupTask::BackupTask(etcpp::Session& session, const std::filesystem::path& backupPath) :
-    mBackup(session.newBackup(backupPath.u8string().c_str())) {}
+BackupTask::BackupTask(etcpp::Session& session, const std::filesystem::path& backupPath, const std::string& addressFilter) :
+    mBackup(session.newBackup(backupPath.u8string().c_str(),
+    addressFilter.empty() ? nullptr : addressFilter.c_str())) {}
 
 void BackupTask::onProgress(float progress) {
     updateProgress(progress);

--- a/cli/bin/tasks/backup_task.hpp
+++ b/cli/bin/tasks/backup_task.hpp
@@ -29,7 +29,7 @@ private:
     CLIProgressBar mProgressBar;
 
 public:
-    BackupTask(etcpp::Session& session, const std::filesystem::path& backupPath);
+    BackupTask(etcpp::Session& session, const std::filesystem::path& backupPath, const std::string& addressFilter = "");
     ~BackupTask() override = default;
     BackupTask(const BackupTask&) = delete;
     BackupTask(BackupTask&&) = delete;

--- a/go-lib/cmd/lib/export_backup.go
+++ b/go-lib/cmd/lib/export_backup.go
@@ -40,7 +40,7 @@ import (
 )
 
 //export etSessionNewBackup
-func etSessionNewBackup(sessionPtr *C.etSession, cExportPath *C.cchar_t, outBackup **C.etBackup) C.etSessionStatus {
+func etSessionNewBackup(sessionPtr *C.etSession, cExportPath *C.cchar_t, cAddressFilter *C.cchar_t, outBackup **C.etBackup) C.etSessionStatus {
 	cSession, ok := resolveSession(sessionPtr)
 	if !ok {
 		return C.ET_SESSION_STATUS_INVALID
@@ -56,7 +56,12 @@ func etSessionNewBackup(sessionPtr *C.etSession, cExportPath *C.cchar_t, outBack
 	exportPath := C.GoString(cExportPath)
 	exportPath = filepath.Join(exportPath, cSession.s.GetUser().Email)
 
-	mailExport := mail.NewExportTask(cSession.ctx, exportPath, cSession.s)
+	addressFilter := ""
+	if cAddressFilter != nil {
+		addressFilter = C.GoString(cAddressFilter)
+	}
+
+	mailExport := mail.NewExportTask(cSession.ctx, exportPath, cSession.s, addressFilter)
 
 	h := internal.NewHandle(&cBackup{
 		csession: cSession,

--- a/go-lib/internal/mail/export_stage_metadata.go
+++ b/go-lib/internal/mail/export_stage_metadata.go
@@ -36,6 +36,7 @@ type MetadataStage struct {
 	outputCh  chan []proton.MessageMetadata
 	pageSize  int
 	splitSize int
+	addressID string
 }
 
 func NewMetadataStage(
@@ -43,6 +44,7 @@ func NewMetadataStage(
 	entry *logrus.Entry,
 	pageSize int,
 	splitSize int,
+	addressID string,
 ) *MetadataStage {
 	return &MetadataStage{
 		client:    client,
@@ -50,6 +52,7 @@ func NewMetadataStage(
 		outputCh:  make(chan []proton.MessageMetadata),
 		pageSize:  pageSize,
 		splitSize: splitSize,
+		addressID: addressID,
 	}
 }
 
@@ -76,8 +79,9 @@ func (m *MetadataStage) Run(
 
 		if lastMessageID != "" {
 			meta, err := client.GetMessageMetadataPage(ctx, 0, m.pageSize, proton.MessageFilter{
-				EndID: lastMessageID,
-				Desc:  true,
+				EndID:     lastMessageID,
+				AddressID: m.addressID,
+				Desc:      true,
 			})
 
 			if err != nil {
@@ -93,7 +97,8 @@ func (m *MetadataStage) Run(
 			metadata = meta
 		} else {
 			meta, err := client.GetMessageMetadataPage(ctx, 0, m.pageSize, proton.MessageFilter{
-				Desc: true,
+				AddressID: m.addressID,
+				Desc:      true,
 			})
 			if err != nil {
 				errReporter.ReportStageError(err)

--- a/lib/include/etsession.hpp
+++ b/lib/include/etsession.hpp
@@ -72,7 +72,7 @@ public:
     [[nodiscard]] std::string getHVSolveURL() const;
     [[nodiscard]] LoginState markHVSolved();
 
-    [[nodiscard]] Backup newBackup(const char* exportPath) const;
+    [[nodiscard]] Backup newBackup(const char* exportPath, const char* addressFilter = nullptr) const;
     [[nodiscard]] Restore newRestore(const char* backupPath) const;
 
     void setUsingDefaultExportPath(const bool usingDefaultExportPath);

--- a/lib/lib/etsession.cpp
+++ b/lib/lib/etsession.cpp
@@ -151,9 +151,9 @@ Session::LoginState Session::getLoginState() const {
     return ls;
 }
 
-Backup Session::newBackup(const char* exportPath) const {
+Backup Session::newBackup(const char* exportPath, const char* addressFilter) const {
     etBackup* exportPtr = nullptr;
-    wrapCCall([&](etSession* ptr) -> etSessionStatus { return etSessionNewBackup(ptr, exportPath, &exportPtr); });
+    wrapCCall([&](etSession* ptr) -> etSessionStatus { return etSessionNewBackup(ptr, exportPath, addressFilter, &exportPtr); });
 
     return Backup(*this, exportPtr);
 }


### PR DESCRIPTION
In Proton Mail you can have multiple addresses associated with an account. To delete an address you must delete all messages associated with that address. Previously the backup tool only supported exporting emails from all addresses in the account. This PR adds the ability to filter which address to export with the -a/--address command line option. The default remains to export emails from all addresses.

# Testing performed
```
./build/cli/proton-mail-export-cli --operation backup -d tmp/ -u myusername@protonmail.com --address myaddress -k
```
I spot checked a few different addresses to confirm they contained the emails for those addresses.
